### PR TITLE
Add replacement section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "contao/core": ">=3.2",
         "contao-community-alliance/composer-plugin": "2.*"
     },
+    "replace": {
+        "contao-legacy/cookiebar": "self.version"
+    },
     "extra": {
         "contao": {
             "sources": {


### PR DESCRIPTION
This is needed so composer knows that there is an actively maintained version of this extension.