### PR TITLE
Fixing Cookie-Path

### DIFF
--- a/assets/cookiebar.js
+++ b/assets/cookiebar.js
@@ -13,6 +13,6 @@ var setCookieBar = function(name) {
 	var cookiebar = document.getElementById('cookiebar');
 	var date = new Date();
 	date.setDate(date.getDate() + 365);
-	document.cookie = name + "=1; expires=" + date.toUTCString();
+	document.cookie = name + "=1; expires=" + date.toUTCString() + ';' + 'path=/';
 	cookiebar.parentNode.removeChild(cookiebar);
 }

--- a/assets/cookiebar.min.js
+++ b/assets/cookiebar.min.js
@@ -8,4 +8,4 @@
  * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
  * @license LGPL
  */
-;var setCookieBar=function(e){var t=document.getElementById("cookiebar");var n=new Date;n.setDate(n.getDate()+365);document.cookie=e+"=1; expires="+n.toUTCString();t.parentNode.removeChild(t)};
+;var setCookieBar=function(e){var t=document.getElementById("cookiebar");var n=new Date;n.setDate(n.getDate()+365);document.cookie=e+"=1; expires="+n.toUTCString() + ';' + 'path=/';t.parentNode.removeChild(t)};


### PR DESCRIPTION
If the user confirms the cookie-usage on a subpage like `domain.tld/about-us/about-us.html` the cookie-path is set to this subpath. This forces the user to repeatedly confirm the cookie on every subpage.

This bug is getting fixed by setting the cookie-path on `/`

Thanks to @lb1601com for support.