### PR TITLE
add missing indexer::stop/continue

### DIFF
--- a/templates/cookiebar/cookiebar_default.html5
+++ b/templates/cookiebar/cookiebar_default.html5
@@ -1,4 +1,5 @@
 
+<!-- indexer::stop -->
 <div id="cookiebar" class="<?php echo $this->position; ?>">
 	<span><?php echo $this->message; ?></span>
 	<button onclick="setCookieBar('<?php echo $this->cookie; ?>'); return false;"><?php echo $this->button; ?></button>
@@ -6,3 +7,4 @@
 	<a href="<?php echo $this->moreHref; ?>" title="<?php echo $this->moreTitle; ?>"><?php echo $this->more; ?></a>
 	<?php endif; ?>
 </div>
+<!-- indexer::continue -->

--- a/templates/cookiebar/cookiebar_default.xhtml
+++ b/templates/cookiebar/cookiebar_default.xhtml
@@ -1,4 +1,5 @@
 
+<!-- indexer::stop -->
 <div id="cookiebar" class="<?php echo $this->position; ?>">
 	<span><?php echo $this->message; ?></span>
 	<button onclick="setCookieBar('<?php echo $this->cookie; ?>'); return false;"><?php echo $this->button; ?></button>
@@ -6,3 +7,4 @@
 	<a href="<?php echo $this->moreHref; ?>" title="<?php echo $this->moreTitle; ?>"><?php echo $this->more; ?></a>
 	<?php endif; ?>
 </div>
+<!-- indexer::continue -->


### PR DESCRIPTION
The contents of the cookie bar should not be indexed by Contao's search indexer.