### PR TITLE
 Prevent cookie bar caching while page cache is enabled in Contao 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 cookiebar Changelog
 ===================
 
+Version 1.3.3 stable (2017-11-27)
+---------------------------------
+
+### Fixed
+- Prevent cookie bar caching while page cache is enabled in Contao 4
+
 Version 1.3.2 stable (2017-02-13)
 ---------------------------------
 

--- a/classes/CookieBar.php
+++ b/classes/CookieBar.php
@@ -118,32 +118,6 @@ class CookieBar extends \Frontend
         return false;
     }
 
-
-    /**
-     * Modify the cached key
-     *
-     * @param string $key
-     *
-     * @return string
-     */
-    public function modifyCacheKey($key)
-    {
-        if ($GLOBALS['objPage']->rootId) {
-            // The page is being cached
-            $rootPage = \PageModel::findByPk($GLOBALS['objPage']->rootId);
-        } else {
-            // Page loaded from cache, global $objPage not available
-            $rootPage = \PageModel::findFirstPublishedRootByHostAndLanguage(\Environment::get('host'), $GLOBALS['TL_LANGUAGE']);
-        }
-
-        if ($rootPage !== null) {
-            $key .= $this->isCookiebarEnabled($rootPage) ? '_cookiebar' : '';
-        }
-
-        return $key;
-    }
-
-
     /**
      * Check whether the cookiebar is enabled and should be displayed
      *

--- a/classes/CookieBar.php
+++ b/classes/CookieBar.php
@@ -20,147 +20,150 @@ namespace Contao;
 class CookieBar extends \Frontend
 {
 
-    /**
-     * Add the cookie information scripts
-     */
-    public function addCookiebarScripts()
-    {
-        if ($this->isCookiebarEnabled()) {
-            $flag = '';
+	/**
+	 * Add the cookie information scripts
+	 */
+	public function addCookiebarScripts()
+	{
+		if ($this->isCookiebarEnabled())
+		{
+			$flag = '';
 
-            // Combine the assets
-            if ($this->getCurrentRootPage()->cookiebar_combineAssets) {
-                $flag = '|static';
-            }
+			// Combine the assets
+			if ($this->getCurrentRootPage()->cookiebar_combineAssets) {
+				$flag = '|static';
+			}
 
-            $GLOBALS['TL_CSS'][]        = 'system/modules/cookiebar/assets/cookiebar.min.css|all' . $flag;
-            $GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/cookiebar/assets/cookiebar.min.js' . $flag;
-        }
-    }
-
-
-    /**
-     * Add the cookie HTML buffer
-     * @param string
-     * @return string
-     */
-    public function addCookiebarBuffer($strContent)
-    {
-        if ($this->isCookiebarEnabled()) {
-            $objRoot = $this->getCurrentRootPage();
-
-            // Place the cookiebar in DOM structure
-            if ($objRoot->cookiebar_placement === 'before_wrapper') {
-                $strContent = str_replace('<div id="wrapper">', '{{cookie_bar|uncached}}<div id="wrapper">', $strContent);
-            } else {
-                $strContent = str_replace('</body>', '{{cookie_bar|uncached}}</body>', $strContent);
-            }
-        }
-
-        return $strContent;
-    }
-
-    /**
-     * Generate the cookie bar template
-     *
-     * @return \Contao\FrontendTemplate The cookie bar template
-     */
-    public function generateCookieBar()
-    {
-        $objRoot     = $this->getCurrentRootPage();
-        $objTemplate = new \FrontendTemplate('cookiebar_default');
-
-        $objTemplate->message  = $objRoot->cookiebar_message;
-        $objTemplate->position = $objRoot->cookiebar_position;
-        $objTemplate->button   = $objRoot->cookiebar_button;
-        $objTemplate->cookie   = $this->getCookiebarName($objRoot);
-        $objTemplate->more     = '';
-
-        // Add the "more" link
-        if ($objRoot->cookiebar_jumpTo > 0) {
-            $objJump = \PageModel::findByPk($objRoot->cookiebar_jumpTo);
-
-            if ($objJump !== null) {
-                $objJump->loadDetails();
-
-                $objTemplate->more      = $GLOBALS['TL_LANG']['MSC']['cookiebar.more'];
-                $objTemplate->moreHref  = ampersand($this->generateFrontendUrl($objJump->row(), null, $objJump->language));
-                $objTemplate->moreTitle = specialchars($GLOBALS['TL_LANG']['MSC']['cookiebar.more']);
-            }
-        }
-
-        return $objTemplate;
-    }
-
-    /**
-     * Add additional tags
-     *
-     * @param $strTag
-     * @param $blnCache
-     * @param $strCache
-     * @param $flags
-     * @param $tags
-     * @param $arrCache
-     * @param $index
-     * @param $count
-     *
-     * @return mixed Return false, if the tag was not replaced, otherwise return the value of the replaced tag
-     */
-    public function replaceCookiebarInsertTags($strTag, $blnCache, $strCache, $flags, $tags, $arrCache, $index, $count)
-    {
-        $elements = explode('::', $strTag);
-
-        switch ($elements[0]) {
-            case 'cookie_bar':
-                return $this->generateCookieBar()->parse();
-        }
-
-        return false;
-    }
-
-    /**
-     * Check whether the cookiebar is enabled and should be displayed
-     *
-     * @param \PageModel $rootPage
-     *
-     * @return boolean
-     */
-    protected function isCookiebarEnabled(\PageModel $rootPage = null)
-    {
-        $objRoot = ($rootPage !== null) ? $rootPage : $this->getCurrentRootPage();
-
-        if ($objRoot->cookiebar_enable && !\Input::cookie($this->getCookiebarName($objRoot))) {
-            return true;
-        }
-
-        return false;
-    }
+			$GLOBALS['TL_CSS'][] = 'system/modules/cookiebar/assets/cookiebar.min.css|all'.$flag;
+			$GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/cookiebar/assets/cookiebar.min.js'.$flag;
+		}
+	}
 
 
-    /**
-     * Get the current root page and return it
-     * @return object
-     */
-    protected function getCurrentRootPage()
-    {
-        global $objPage;
-        $strKey = 'COOKIEBAR_ROOT_' . $objPage->rootId;
 
-        if (!\Cache::has($strKey)) {
-            \Cache::set($strKey, \PageModel::findByPk($objPage->rootId));
-        }
+         /**
+	 * Add the cookie HTML buffer
+	 * @param string
+	 * @return string
+	 */
+	public function addCookiebarBuffer($strContent)
+	{
+		if ($this->isCookiebarEnabled()) 
+		{
+			$objRoot = $this->getCurrentRootPage();
 
-        return \Cache::get($strKey);
-    }
+			// Place the cookiebar in DOM structure
+			if ($objRoot->cookiebar_placement === 'before_wrapper') {
+				$strContent = str_replace('<div id="wrapper">', '{{cookie_bar|uncached}}<div id="wrapper">', $strContent);
+			} else {
+				$strContent = str_replace('</body>', '{{cookie_bar|uncached}}</body>', $strContent);
+			}
+		}
+
+		return $strContent;
+	}
+
+         /**
+         * Generate the cookie bar template
+         *
+         * @return \Contao\FrontendTemplate The cookie bar template
+         */
+	public function generateCookieBar()
+	{
+		$objRoot     = $this->getCurrentRootPage();
+		$objTemplate = new \FrontendTemplate('cookiebar_default');
+
+		$objTemplate->message  = $objRoot->cookiebar_message;
+		$objTemplate->position = $objRoot->cookiebar_position;
+		$objTemplate->button   = $objRoot->cookiebar_button;
+		$objTemplate->cookie   = $this->getCookiebarName($objRoot);
+		$objTemplate->more     = '';
+
+		// Add the "more" link
+		if ($objRoot->cookiebar_jumpTo > 0) {
+			$objJump = \PageModel::findByPk($objRoot->cookiebar_jumpTo);
+
+			if ($objJump !== null) {
+				$objJump->loadDetails();
+
+				$objTemplate->more      = $GLOBALS['TL_LANG']['MSC']['cookiebar.more'];
+				$objTemplate->moreHref  = ampersand($this->generateFrontendUrl($objJump->row(), null, $objJump->language));
+				$objTemplate->moreTitle = specialchars($GLOBALS['TL_LANG']['MSC']['cookiebar.more']);
+			}
+		}
+
+		return $objTemplate;
+	}
+
+	/**
+	* Add additional tags
+	*
+	* @param $strTag
+	* @param $blnCache
+	* @param $strCache
+	* @param $flags
+	* @param $tags
+	* @param $arrCache
+	* @param $index
+	* @param $count
+	*
+	* @return mixed Return false, if the tag was not replaced, otherwise return the value of the replaced tag
+	*/
+	public function replaceCookiebarInsertTags($strTag, $blnCache, $strCache, $flags, $tags, $arrCache, $index, $count)
+	{
+		$elements = explode('::', $strTag);
+
+		switch ($elements[0]) {
+			case 'cookie_bar':
+				return $this->generateCookieBar()->parse();
+		}
+
+		return false;
+	}
+
+	/**
+	* Check whether the cookiebar is enabled and should be displayed
+	*
+	* @param \PageModel $rootPage
+	*
+	* @return boolean
+	*/
+	protected function isCookiebarEnabled(\PageModel $rootPage = null)
+	{
+		$objRoot = ($rootPage !== null) ? $rootPage : $this->getCurrentRootPage();
+
+		if ($objRoot->cookiebar_enable && !\Input::cookie($this->getCookiebarName($objRoot))) {
+			return true;
+		}
+
+		return false;
+	}
 
 
-    /**
-     * Return the cookie name
-     * @param object
-     * @return string
-     */
-    protected function getCookiebarName($objPage)
-    {
-        return 'COOKIEBAR_' . $objPage->id;
-    }
+	/**
+	* Get the current root page and return it
+	* @return object
+	*/
+	protected function getCurrentRootPage()
+	{
+		global $objPage;
+		$strKey = 'COOKIEBAR_ROOT_' . $objPage->rootId;
+
+		if (!\Cache::has($strKey)) {
+			\Cache::set($strKey, \PageModel::findByPk($objPage->rootId));
+		}
+
+		return \Cache::get($strKey);
+	}
+
+
+	/**
+	* Return the cookie name
+	* @param object
+	* @return string
+	*/
+	protected function getCookiebarName($objPage)
+	{
+		return 'COOKIEBAR_' . $objPage->id;
+	}
 }

--- a/classes/CookieBar.php
+++ b/classes/CookieBar.php
@@ -20,13 +20,12 @@ namespace Contao;
 class CookieBar extends \Frontend
 {
 
-	/**
-	 * Add the cookie information scripts
-	 */
-	public function addCookiebarScripts()
-	{
-		if ($this->isCookiebarEnabled())
-		{
+    /**
+     * Add the cookie information scripts
+     */
+    public function addCookiebarScripts()
+    {
+        if ($this->isCookiebarEnabled()) {
             $flag = '';
 
             // Combine the assets
@@ -34,127 +33,160 @@ class CookieBar extends \Frontend
                 $flag = '|static';
             }
 
-			$GLOBALS['TL_CSS'][] = 'system/modules/cookiebar/assets/cookiebar.min.css|all'.$flag;
-			$GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/cookiebar/assets/cookiebar.min.js'.$flag;
-		}
-	}
+            $GLOBALS['TL_CSS'][]        = 'system/modules/cookiebar/assets/cookiebar.min.css|all' . $flag;
+            $GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/cookiebar/assets/cookiebar.min.js' . $flag;
+        }
+    }
 
 
-	/**
-	 * Add the cookie HTML buffer
-	 * @param string
-	 * @return string
-	 */
-	public function addCookiebarBuffer($strContent)
-	{
-		if ($this->isCookiebarEnabled())
-		{
-			$objRoot = $this->getCurrentRootPage();
-			$objTemplate = new \FrontendTemplate('cookiebar_default');
+    /**
+     * Add the cookie HTML buffer
+     * @param string
+     * @return string
+     */
+    public function addCookiebarBuffer($strContent)
+    {
+        if ($this->isCookiebarEnabled()) {
+            $objRoot = $this->getCurrentRootPage();
 
-			$objTemplate->message = $objRoot->cookiebar_message;
-			$objTemplate->position = $objRoot->cookiebar_position;
-			$objTemplate->button = $objRoot->cookiebar_button;
-			$objTemplate->cookie = $this->getCookiebarName($objRoot);
-			$objTemplate->more = '';
+            // Place the cookiebar in DOM structure
+            if ($objRoot->cookiebar_placement === 'before_wrapper') {
+                $strContent = str_replace('<div id="wrapper">', '{{cookie_bar|uncached}}<div id="wrapper">', $strContent);
+            } else {
+                $strContent = str_replace('</body>', '{{cookie_bar|uncached}}</body>', $strContent);
+            }
+        }
 
-			// Add the "more" link
-			if ($objRoot->cookiebar_jumpTo > 0)
-			{
-				$objJump = \PageModel::findByPk($objRoot->cookiebar_jumpTo);
+        return $strContent;
+    }
 
-				if ($objJump !== null)
-				{
-					$objJump->loadDetails();
+    /**
+     * Generate the cookie bar template
+     *
+     * @return \Contao\FrontendTemplate The cookie bar template
+     */
+    public function generateCookieBar()
+    {
+        $objRoot     = $this->getCurrentRootPage();
+        $objTemplate = new \FrontendTemplate('cookiebar_default');
 
-					$objTemplate->more = $GLOBALS['TL_LANG']['MSC']['cookiebar.more'];
-					$objTemplate->moreHref = ampersand($this->generateFrontendUrl($objJump->row(), null, $objJump->language));
-					$objTemplate->moreTitle = specialchars($GLOBALS['TL_LANG']['MSC']['cookiebar.more']);
-				}
-			}
+        $objTemplate->message  = $objRoot->cookiebar_message;
+        $objTemplate->position = $objRoot->cookiebar_position;
+        $objTemplate->button   = $objRoot->cookiebar_button;
+        $objTemplate->cookie   = $this->getCookiebarName($objRoot);
+        $objTemplate->more     = '';
 
-			// Place the cookiebar in DOM structure
-			if ($objRoot->cookiebar_placement === 'before_wrapper') {
-				$strContent = str_replace('<div id="wrapper">', $objTemplate->parse() . '<div id="wrapper">', $strContent);
-			} else {
-				$strContent = str_replace('</body>', $objTemplate->parse() . '</body>', $strContent);
-			}
-		}
+        // Add the "more" link
+        if ($objRoot->cookiebar_jumpTo > 0) {
+            $objJump = \PageModel::findByPk($objRoot->cookiebar_jumpTo);
 
-		return $strContent;
-	}
+            if ($objJump !== null) {
+                $objJump->loadDetails();
 
+                $objTemplate->more      = $GLOBALS['TL_LANG']['MSC']['cookiebar.more'];
+                $objTemplate->moreHref  = ampersand($this->generateFrontendUrl($objJump->row(), null, $objJump->language));
+                $objTemplate->moreTitle = specialchars($GLOBALS['TL_LANG']['MSC']['cookiebar.more']);
+            }
+        }
 
-	/**
-	 * Modify the cached key
-	 *
-	 * @param string $key
-	 *
-	 * @return string
-	 */
-	public function modifyCacheKey($key)
-	{
-		if ($GLOBALS['objPage']->rootId) {
-			// The page is being cached
-			$rootPage = \PageModel::findByPk($GLOBALS['objPage']->rootId);
-		} else {
-			// Page loaded from cache, global $objPage not available
-			$rootPage = \PageModel::findFirstPublishedRootByHostAndLanguage(\Environment::get('host'), $GLOBALS['TL_LANGUAGE']);
-		}
+        return $objTemplate;
+    }
 
-		if ($rootPage !== null) {
-			$key .= $this->isCookiebarEnabled($rootPage) ? '_cookiebar' : '';
-		}
+    /**
+     * Add additional tags
+     *
+     * @param $strTag
+     * @param $blnCache
+     * @param $strCache
+     * @param $flags
+     * @param $tags
+     * @param $arrCache
+     * @param $index
+     * @param $count
+     *
+     * @return mixed Return false, if the tag was not replaced, otherwise return the value of the replaced tag
+     */
+    public function replaceCookiebarInsertTags($strTag, $blnCache, $strCache, $flags, $tags, $arrCache, $index, $count)
+    {
+        $elements = explode('::', $strTag);
 
-		return $key;
-	}
+        switch ($elements[0]) {
+            case 'cookie_bar':
+                return $this->generateCookieBar()->parse();
+        }
 
-
-	/**
-	 * Check whether the cookiebar is enabled and should be displayed
-	 *
-	 * @param \PageModel $rootPage
-	 *
-	 * @return boolean
-	 */
-	protected function isCookiebarEnabled(\PageModel $rootPage = null)
-	{
-		$objRoot = ($rootPage !== null) ? $rootPage : $this->getCurrentRootPage();
-
-		if ($objRoot->cookiebar_enable && !\Input::cookie($this->getCookiebarName($objRoot)))
-		{
-			return true;
-		}
-
-		return false;
-	}
+        return false;
+    }
 
 
-	/**
-	 * Get the current root page and return it
-	 * @return object
-	 */
-	protected function getCurrentRootPage()
-	{
-		global $objPage;
-		$strKey = 'COOKIEBAR_ROOT_' . $objPage->rootId;
+    /**
+     * Modify the cached key
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function modifyCacheKey($key)
+    {
+        if ($GLOBALS['objPage']->rootId) {
+            // The page is being cached
+            $rootPage = \PageModel::findByPk($GLOBALS['objPage']->rootId);
+        } else {
+            // Page loaded from cache, global $objPage not available
+            $rootPage = \PageModel::findFirstPublishedRootByHostAndLanguage(\Environment::get('host'), $GLOBALS['TL_LANGUAGE']);
+        }
 
-		if (!\Cache::has($strKey))
-		{
-			\Cache::set($strKey, \PageModel::findByPk($objPage->rootId));
-		}
+        if ($rootPage !== null) {
+            $key .= $this->isCookiebarEnabled($rootPage) ? '_cookiebar' : '';
+        }
 
-		return \Cache::get($strKey);
-	}
+        return $key;
+    }
 
 
-	/**
-	 * Return the cookie name
-	 * @param object
-	 * @return string
-	 */
-	protected function getCookiebarName($objPage)
-	{
-		return 'COOKIEBAR_' . $objPage->id;
-	}
+    /**
+     * Check whether the cookiebar is enabled and should be displayed
+     *
+     * @param \PageModel $rootPage
+     *
+     * @return boolean
+     */
+    protected function isCookiebarEnabled(\PageModel $rootPage = null)
+    {
+        $objRoot = ($rootPage !== null) ? $rootPage : $this->getCurrentRootPage();
+
+        if ($objRoot->cookiebar_enable && !\Input::cookie($this->getCookiebarName($objRoot))) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Get the current root page and return it
+     * @return object
+     */
+    protected function getCurrentRootPage()
+    {
+        global $objPage;
+        $strKey = 'COOKIEBAR_ROOT_' . $objPage->rootId;
+
+        if (!\Cache::has($strKey)) {
+            \Cache::set($strKey, \PageModel::findByPk($objPage->rootId));
+        }
+
+        return \Cache::get($strKey);
+    }
+
+
+    /**
+     * Return the cookie name
+     * @param object
+     * @return string
+     */
+    protected function getCookiebarName($objPage)
+    {
+        return 'COOKIEBAR_' . $objPage->id;
+    }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -22,6 +22,12 @@
 /**
  * Hooks
  */
-$GLOBALS['TL_HOOKS']['generatePage'][] = array('CookieBar', 'addCookiebarScripts');
-$GLOBALS['TL_HOOKS']['getCacheKey'][] = array('CookieBar', 'modifyCacheKey');
-$GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = array('CookieBar', 'addCookiebarBuffer');
+$GLOBALS['TL_HOOKS']['generatePage'][] = ['CookieBar', 'addCookiebarScripts'];
+
+// not longer supported in contao 4
+if (version_compare(VERSION, '4.0', '<')) {
+    $GLOBALS['TL_HOOKS']['getCacheKey'][] = ['CookieBar', 'modifyCacheKey'];
+}
+
+$GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = ['CookieBar', 'addCookiebarBuffer'];
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][]      = ['CookieBar', 'replaceCookiebarInsertTags'];

--- a/config/config.php
+++ b/config/config.php
@@ -22,6 +22,6 @@
 /**
  * Hooks
  */
-$GLOBALS['TL_HOOKS']['generatePage'][]           = ['CookieBar', 'addCookiebarScripts'];
+$GLOBALS['TL_HOOKS']['generatePage'][] = ['CookieBar', 'addCookiebarScripts'];
 $GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = ['CookieBar', 'addCookiebarBuffer'];
-$GLOBALS['TL_HOOKS']['replaceInsertTags'][]      = ['CookieBar', 'replaceCookiebarInsertTags'];
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = ['CookieBar', 'replaceCookiebarInsertTags'];

--- a/config/config.php
+++ b/config/config.php
@@ -22,12 +22,6 @@
 /**
  * Hooks
  */
-$GLOBALS['TL_HOOKS']['generatePage'][] = ['CookieBar', 'addCookiebarScripts'];
-
-// not longer supported in contao 4
-if (version_compare(VERSION, '4.0', '<')) {
-    $GLOBALS['TL_HOOKS']['getCacheKey'][] = ['CookieBar', 'modifyCacheKey'];
-}
-
+$GLOBALS['TL_HOOKS']['generatePage'][]           = ['CookieBar', 'addCookiebarScripts'];
 $GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = ['CookieBar', 'addCookiebarBuffer'];
 $GLOBALS['TL_HOOKS']['replaceInsertTags'][]      = ['CookieBar', 'replaceCookiebarInsertTags'];


### PR DESCRIPTION
@qzminski 

Because the hook `$GLOBALS['TL_HOOKS']['getCacheKey']` is no longer supported in contao 4, when page cache is enabled, the cookie bar will be rendered all time, whether or not the user accepted the cookie message by clicking the button. 

To maintain page cache within contao 4 i created an uncached inserttag `{{cookie_bar|uncached}}` that will be added within the `outputFrontendTemplate` hook and afterward replaced by the `replaceInsertTags` hook, ignoring page cache for the cookie bar itself. 

The uncached inserttag flag works in both contao 3 and 4, so i dropped the `modifyCacheKey` hook.