### PR TITLE
Fixed buggy cookie check

### DIFF
--- a/assets/src/cookiebar.js
+++ b/assets/src/cookiebar.js
@@ -9,8 +9,9 @@ document.addEventListener('DOMContentLoaded', function () {
     var cookieName = cookiebar.dataset.cookiebar;
 
     // Return if the cookie is still valid
-    if (document.cookie.indexOf(cookieName) !== -1) {
-        return;
+    var cookies = document.cookie ? document.cookie.split('; ') : [];
+    for (const c in cookies) {
+        if (cookies[c].split('=').slice(1).join('=') == cookieName) return;
     }
 
     var bodyCssClass = 'cookiebar-active';


### PR DESCRIPTION
If you have two start pages and they for example have the ids 1 and 18, the current cookiename check with `indexOf` leads to a bug. If you visited page 18 and switch to 1, the cookie bar doesnt trigger because `COOKIEBAR_18` is set and it contains `COOKIEBAR_1`, so `indexOf` returns true