### PR TITLE
Support the new Contao 4.9 palette "rootfallback"

### DIFF
--- a/dca/tl_page.php
+++ b/dca/tl_page.php
@@ -16,6 +16,7 @@
 $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'cookiebar_enable';
 $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'cookiebar_analyticsCheckbox';
 $GLOBALS['TL_DCA']['tl_page']['palettes']['root'] .= ';{cookiebar_legend},cookiebar_enable';
+$GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'] .= ';{cookiebar_legend},cookiebar_enable';
 
 $GLOBALS['TL_DCA']['tl_page']['subpalettes']['cookiebar_enable'] = 'cookiebar_message,cookiebar_button,cookiebar_ttl,cookiebar_url,cookiebar_link,cookiebar_position,cookiebar_placement,cookiebar_combineAssets,cookiebar_includeCss,cookiebar_analyticsCheckbox';
 $GLOBALS['TL_DCA']['tl_page']['subpalettes']['cookiebar_analyticsCheckbox'] = 'cookiebar_analyticsLabel';

--- a/dca/tl_page.php
+++ b/dca/tl_page.php
@@ -16,7 +16,9 @@
 $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'cookiebar_enable';
 $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'cookiebar_analyticsCheckbox';
 $GLOBALS['TL_DCA']['tl_page']['palettes']['root'] .= ';{cookiebar_legend},cookiebar_enable';
-$GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'] .= ';{cookiebar_legend},cookiebar_enable';
+if (isset($GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'])) {
+    $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'] .= ';{cookiebar_legend},cookiebar_enable';
+}
 
 $GLOBALS['TL_DCA']['tl_page']['subpalettes']['cookiebar_enable'] = 'cookiebar_message,cookiebar_button,cookiebar_ttl,cookiebar_url,cookiebar_link,cookiebar_position,cookiebar_placement,cookiebar_combineAssets,cookiebar_includeCss,cookiebar_analyticsCheckbox';
 $GLOBALS['TL_DCA']['tl_page']['subpalettes']['cookiebar_analyticsCheckbox'] = 'cookiebar_analyticsLabel';


### PR DESCRIPTION
In Contao 4.9 there is a new tl_page palette called "rootfallback". Without this changes the cookiebar settings are not shown on root page in backend, when "language fallback" is selected.

The subject was also mentioned here:
https://community.contao.org/de/showthread.php?76966-Neue-Palette-f%C3%BCr-Root-Pages-mit-Fallback

